### PR TITLE
Fix for entrypoint if started w/ docker run.

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,7 +14,7 @@ then
 	roslaunch exomy exomy.launch
 
 	bash
-elif [[ $1 == "ros" ]]
+elif [[ $1 == "devel" ]]
 then
 	cd /root/exomy_ws
 	source /opt/ros/melodic/setup.bash

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-if [ $1 == "config" ]
+if [[ $1 == "config" ]]
 then
 	cd /root/exomy_ws/src/exomy/scripts
 	bash
-elif [ $1 == "autostart" ]
+elif [[ $1 == "autostart" ]]
 then
 	source /opt/ros/melodic/setup.bash
 	cd /root/exomy_ws
@@ -14,7 +14,7 @@ then
 	roslaunch exomy exomy.launch
 
 	bash
-elif [ $1 == "ros" ]
+elif [[ $1 == "ros" ]]
 then
 	cd /root/exomy_ws
 	source /opt/ros/melodic/setup.bash


### PR DESCRIPTION
running
```
docker run exomy
```
instead of the .sh script throws the following error since `$1` from `entrypoint.sh` is not set.
```
/entrypoint.sh: line 2: [: ==: unary operator expected
/entrypoint.sh: line 6: [: ==: unary operator expected
/entrypoint.sh: line 17: [: ==: unary operator expected
```

This was fixed as described here:
https://stackoverflow.com/questions/13617843/unary-operator-expected-error-in-bash-if-condition

However, when I run the docker container w/ `docker run exomy -it` it stops immediately.

Running the `*.sh` scripts still works perfectly.

I think I'm be missing something obv in respect to running it or the modifification of the entrypoint causes it not to get to the last ```else
  bash
```

line.