### PR TITLE
Refactor motor actuation code and fix stop latency

### DIFF
--- a/src/motor_node.py
+++ b/src/motor_node.py
@@ -11,15 +11,18 @@ global watchdog_timer
 def callback(cmds):
     motors.setSteering(cmds.motor_angles)
     motors.setDriving(cmds.motor_speeds)
+    
     global watchdog_timer
     watchdog_timer.shutdown()
-    watchdog_timer = rospy.Timer(rospy.Duration(1), watchdog, oneshot=True)
+    # If this timer runs longer than the duration specified,
+    # then watchdog() is called stopping the driving motors.
+    watchdog_timer = rospy.Timer(rospy.Duration(5.0), watchdog, oneshot=True)
 
 def shutdown():
     motors.stopMotors()
 
 def watchdog(event):
-    rospy.loginfo("Watchdog fired")
+    rospy.loginfo("Watchdog fired. Stopping driving motors.")
     motors.stopMotors()
 
 if __name__ == "__main__":
@@ -27,9 +30,9 @@ if __name__ == "__main__":
     rospy.init_node("motors")
     rospy.loginfo("Starting the motors node")
     rospy.on_shutdown(shutdown)
-    global watchdog_timer
-    watchdog_timer =  rospy.Timer(rospy.Duration(1), watchdog, oneshot=True)
     
+    global watchdog_timer
+    watchdog_timer =  rospy.Timer(rospy.Duration(1.0), watchdog, oneshot=True)
 
     sub = rospy.Subscriber("/motor_commands",Commands, callback, queue_size=1)
 

--- a/src/motors.py
+++ b/src/motors.py
@@ -10,36 +10,49 @@ import Adafruit_PCA9685
 
 class Motors():
     '''
-    Motors class contains all functions to control the steering and driving motors.
+    Motors class contains all functions to control the steering and driving
     '''
 
+
     # Define wheel names
-    # rr- -rl
-    # cr- -cl
-    #    |
-    # fr- -fl
     FL, FR, CL, CR, RL, RR = range(0, 6)
+    
+    # Motor commands are assuming positiv=driving_forward, negative=driving_backwards.
+    # The driving direction of the left side has to be inverted for this to apply to all wheels.
+    wheel_directions = [-1, 1, -1, 1, -1, 1]
+    
+    # 1 fl-||-fr 2
+    #      ||
+    # 3 cl-||-cr 4
+    # 5 rl====rr 6
+
 
     def __init__(self):
-
+        
+        # Dictionary containing the pins of all motors
+        self.pins = {
+            'drive': {},
+            'steer': {}
+            }
+        
         # Set variables for the GPIO motor pins
-        self.pin_drive_fl = rospy.get_param("pin_drive_fl")
-        self.pin_steer_fl = rospy.get_param("pin_steer_fl")
+        self.pins['drive'][self.FL] = rospy.get_param("pin_drive_fl")
+        self.pins['steer'][self.FL] = rospy.get_param("pin_steer_fl")
 
-        self.pin_drive_fr = rospy.get_param("pin_drive_fr")
-        self.pin_steer_fr = rospy.get_param("pin_steer_fr")
+        self.pins['drive'][self.FR] = rospy.get_param("pin_drive_fr")
+        self.pins['steer'][self.FR] = rospy.get_param("pin_steer_fr")
 
-        self.pin_drive_cl = rospy.get_param("pin_drive_cl")
-        self.pin_steer_cl = rospy.get_param("pin_steer_cl")
+        self.pins['drive'][self.CL] = rospy.get_param("pin_drive_cl")
+        self.pins['steer'][self.CL] = rospy.get_param("pin_steer_cl")
 
-        self.pin_drive_cr = rospy.get_param("pin_drive_cr")
-        self.pin_steer_cr = rospy.get_param("pin_steer_cr")
+        self.pins['drive'][self.CR] = rospy.get_param("pin_drive_cr")
+        self.pins['steer'][self.CR] = rospy.get_param("pin_steer_cr")
 
-        self.pin_drive_rl = rospy.get_param("pin_drive_rl")
-        self.pin_steer_rl = rospy.get_param("pin_steer_rl")
+        self.pins['drive'][self.RL] = rospy.get_param("pin_drive_rl")
+        self.pins['steer'][self.RL] = rospy.get_param("pin_steer_rl")
 
-        self.pin_drive_rr = rospy.get_param("pin_drive_rr")
-        self.pin_steer_rr = rospy.get_param("pin_steer_rr")
+        self.pins['drive'][self.RR] = rospy.get_param("pin_drive_rr")
+        self.pins['steer'][self.RR] = rospy.get_param("pin_steer_rr")
 
         # PWM characteristics
         self.pwm = Adafruit_PCA9685.PCA9685()
@@ -60,126 +73,55 @@ class Motors():
         self.driving_pwm_upper_limit = 500
         self.driving_pwm_range = rospy.get_param("drive_range")
 
-        # Set the GPIO to software PWM at 'Frequency' Hertz
-        self.driving_motors = [None] * 6
-        self.steering_motors = [None] * 6
-
-        # Set steering motors to neutral values
-        self.pwm.set_pwm(self.pin_steer_fl, 0,
-                         self.steering_pwm_neutral[self.FL])
-        time.sleep(0.1)
-        self.pwm.set_pwm(self.pin_steer_fr, 0,
-                         self.steering_pwm_neutral[self.FR])
-        time.sleep(0.1)
-        self.pwm.set_pwm(self.pin_steer_cl, 0,
-                         self.steering_pwm_neutral[self.CL])
-        time.sleep(0.1)
-        self.pwm.set_pwm(self.pin_steer_cr, 0,
-                         self.steering_pwm_neutral[self.CR])
-        time.sleep(0.1)
-        self.pwm.set_pwm(self.pin_steer_rl, 0,
-                         self.steering_pwm_neutral[self.RL])
-        time.sleep(0.1)
-        self.pwm.set_pwm(self.pin_steer_rr, 0,
-                         self.steering_pwm_neutral[self.RR])
-        time.sleep(0.1)
+        # Set steering motors to neutral values (straight)
+        for wheel_name, motor_pin in self.pins['steer'].items(): 
+            self.pwm.set_pwm(motor_pin, 0,
+                             self.steering_pwm_neutral[wheel_name])
+            time.sleep(0.1)
         
         self.wiggle()
 
 
     def wiggle(self):
         time.sleep(0.1)
-        self.pwm.set_pwm(self.pin_steer_fl, 0,
+        self.pwm.set_pwm(self.pins['steer'][self.FL], 0,
                          int(self.steering_pwm_neutral[self.FL] + self.steering_pwm_range * 0.3))
         time.sleep(0.1)
-        self.pwm.set_pwm(self.pin_steer_fr, 0,
+        self.pwm.set_pwm(self.pins['steer'][self.FR], 0,
                          int(self.steering_pwm_neutral[self.FR] + self.steering_pwm_range * 0.3))
         time.sleep(0.3)
-        self.pwm.set_pwm(self.pin_steer_fl, 0,
+        self.pwm.set_pwm(self.pins['steer'][self.FL], 0,
                          int(self.steering_pwm_neutral[self.FL] - self.steering_pwm_range * 0.3))
         time.sleep(0.1)
-        self.pwm.set_pwm(self.pin_steer_fr, 0,
+        self.pwm.set_pwm(self.pins['steer'][self.FR], 0,
                          int(self.steering_pwm_neutral[self.FR] - self.steering_pwm_range * 0.3))
         time.sleep(0.3)
-        self.pwm.set_pwm(self.pin_steer_fl, 0,
+        self.pwm.set_pwm(self.pins['steer'][self.FL], 0,
                          int(self.steering_pwm_neutral[self.FL]))
         time.sleep(0.1)
-        self.pwm.set_pwm(self.pin_steer_fr, 0,
+        self.pwm.set_pwm(self.pins['steer'][self.FR], 0,
                          int(self.steering_pwm_neutral[self.FR]))
         time.sleep(0.3)
 
     def setSteering(self, steering_command):
-        duty_cycle = int(
-            self.steering_pwm_neutral[self.FL] + steering_command[self.FL]/90.0 * self.steering_pwm_range)
-        self.pwm.set_pwm(self.pin_steer_fl, 0, duty_cycle)
-
-        duty_cycle = int(
-            self.steering_pwm_neutral[self.FR] + steering_command[self.FR]/90.0 * self.steering_pwm_range)
-        self.pwm.set_pwm(self.pin_steer_fr, 0, duty_cycle)
-
-        duty_cycle = int(
-            self.steering_pwm_neutral[self.CL] + steering_command[self.CL]/90.0 * self.steering_pwm_range)
-        self.pwm.set_pwm(self.pin_steer_cl, 0, duty_cycle)
-
-        duty_cycle = int(
-            self.steering_pwm_neutral[self.CR] + steering_command[self.CR]/90.0 * self.steering_pwm_range)
-        self.pwm.set_pwm(self.pin_steer_cr, 0, duty_cycle)
-
-        duty_cycle = int(
-            self.steering_pwm_neutral[self.RL] + steering_command[self.RL]/90.0 * self.steering_pwm_range)
-        self.pwm.set_pwm(self.pin_steer_rl, 0, duty_cycle)
-
-        duty_cycle = int(
-            self.steering_pwm_neutral[self.RR] + steering_command[self.RR]/90.0 * self.steering_pwm_range)
-        self.pwm.set_pwm(self.pin_steer_rr, 0, duty_cycle)
+        # Loop through pin dictionary. The items key is the wheel_name and the value the pin.        
+        for wheel_name, motor_pin in self.pins['steer'].items():
+            duty_cycle = int(
+                self.steering_pwm_neutral[wheel_name] + steering_command[wheel_name]/90.0 * self.steering_pwm_range)
+            
+            self.pwm.set_pwm(motor_pin, 0, duty_cycle)
 
     def setDriving(self, driving_command):
-        if(driving_command[self.FL] == 0.0):
-            duty_cycle = 0
-        else:
-            duty_cycle = int(self.driving_pwm_neutral -
-                             driving_command[self.FL]/100.0 * self.driving_pwm_range)
-        self.pwm.set_pwm(self.pin_drive_fl, 0, duty_cycle)
-
-        if(driving_command[self.FR] == 0.0):
-            duty_cycle = 0
-        else:
+        # Loop through pin dictionary. The items key is the wheel_name and the value the pin.
+        for wheel_name, motor_pin in self.pins['drive'].items():
             duty_cycle = int(self.driving_pwm_neutral +
-                             driving_command[self.FR]/100.0 * self.driving_pwm_range)
-        self.pwm.set_pwm(self.pin_drive_fr, 0, duty_cycle)
-
-        if(driving_command[self.CL] == 0.0):
-            duty_cycle = 0
-        else:
-            duty_cycle = int(self.driving_pwm_neutral -
-                             driving_command[self.CL]/100.0 * self.driving_pwm_range)
-        self.pwm.set_pwm(self.pin_drive_cl, 0, duty_cycle)
-
-        if(driving_command[self.CR] == 0.0):
-            duty_cycle = 0
-        else:
-            duty_cycle = int(self.driving_pwm_neutral +
-                             driving_command[self.CR]/100.0 * self.driving_pwm_range)
-        self.pwm.set_pwm(self.pin_drive_cr, 0, duty_cycle)
-
-        if(driving_command[self.RL] == 0.0):
-            duty_cycle = 0
-        else:
-            duty_cycle = int(self.driving_pwm_neutral -
-                             driving_command[self.RL]/100.0 * self.driving_pwm_range)
-        self.pwm.set_pwm(self.pin_drive_rl, 0, duty_cycle)
-
-        if(driving_command[self.RR] == 0.0):
-            duty_cycle = 0
-        else:
-            duty_cycle = int(self.driving_pwm_neutral +
-                             driving_command[self.RR]/100.0 * self.driving_pwm_range)
-        self.pwm.set_pwm(self.pin_drive_rr, 0, duty_cycle)
+                             driving_command[wheel_name]/100.0 * self.driving_pwm_range * self.wheel_directions[wheel_name])
+            
+            self.pwm.set_pwm(motor_pin, 0, duty_cycle)
 
     def stopMotors(self):
-        self.pwm.set_pwm(self.pin_drive_fl, 0, 0)
-        self.pwm.set_pwm(self.pin_drive_fr, 0, 0)
-        self.pwm.set_pwm(self.pin_drive_cl, 0, 0)
-        self.pwm.set_pwm(self.pin_drive_cr, 0, 0)
-        self.pwm.set_pwm(self.pin_drive_rl, 0, 0)
-        self.pwm.set_pwm(self.pin_drive_rr, 0, 0)
+        # Set driving wheels to neutral position to stop them
+        duty_cycle = int(self.driving_pwm_neutral)
+        
+        for wheel_name, motor_pin in self.pins['drive'].items():
+            self.pwm.set_pwm(motor_pin, 0, duty_cycle)


### PR DESCRIPTION
The motors would only stop with a 1 s delay as pwm was set to 0 instead
of its neutral pwm value.

The code refactor simplifies the files and reduces copy pasta code

Increase watchdog duration to 5s for more responsive behaviour.