### PR TITLE
Remove catkin_make from devel mode

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,8 +18,8 @@ elif [[ $1 == "devel" ]]
 then
 	cd /root/exomy_ws
 	source /opt/ros/melodic/setup.bash
-	catkin_make
-	source devel/setup.bash
+	# catkin_make
+	# source devel/setup.bash
 	bash
 else
 	bash


### PR DESCRIPTION
If catkin_make fails the container will not be started in devel mode, therefore it needs to be removed.