### PR TITLE
Correct Ackermann/Point turn steering / Speed selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 config/exomy.yaml
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.pyc
 config/exomy.yaml
 .DS_Store
+*.code-workspace
+.vscode/
+__pycache__

--- a/src/locomotion_modes.py
+++ b/src/locomotion_modes.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
-
 import enum
 
-
 class LocomotionMode(enum.Enum):
-    FAKE_ACKERMANN = 0
     ACKERMANN = 1
     POINT_TURN = 2
     CRABBING = 3

--- a/src/locomotion_modes.py
+++ b/src/locomotion_modes.py
@@ -2,6 +2,7 @@
 import enum
 
 class LocomotionMode(enum.Enum):
+    FAKE_ACKERMANN = 0
     ACKERMANN = 1
     POINT_TURN = 2
     CRABBING = 3

--- a/src/rover.py
+++ b/src/rover.py
@@ -186,7 +186,7 @@ class Rover():
         if(self.locomotion_mode == LocomotionMode.POINT_TURN.value):
             point_turn_angle = int(math.degrees(math.atan((self.wheel_x+self.wheel_fx) / self.wheel_y)))
             
-            point_turn_angle_center = int(math.degrees(math.atan((((self.wheel_x+self.wheel_fx) / 2 ) - self.wheel_x) / (self.wheel_y / 2))))
+            point_turn_angle_center = int(math.degrees(math.atan((((self.wheel_x+self.wheel_fx) / 2 ) - self.wheel_fx) / (self.wheel_y / 2))))
             #For ExoMy approx. 55 degree
             steering_angles[self.FL] = point_turn_angle
             steering_angles[self.FR] = -point_turn_angle
@@ -291,6 +291,8 @@ class Rover():
                 return motor_speeds
 
         if (self.locomotion_mode == LocomotionMode.POINT_TURN.value):
+            v = driving_command
+            
             outer_turning_radius = math.sqrt(math.pow(self.wheel_x+self.wheel_fx,2) + math.pow(self.wheel_y,2)) / 2
             inner_turning_radius = math.sqrt(math.pow(((self.wheel_x+self.wheel_fx) / 2 ) - self.wheel_x,2) + math.pow((self.wheel_y / 2),2))
             
@@ -327,6 +329,8 @@ class Rover():
             return motor_speeds
 
         if(self.locomotion_mode == LocomotionMode.CRABBING.value):
+            v = driving_command
+            
             if(driving_command > 0):
                 if(steering_command > 0):
                     motor_speeds[self.FL] = v

--- a/src/rover.py
+++ b/src/rover.py
@@ -184,10 +184,12 @@ class Rover():
             return steering_angles
 
         if(self.locomotion_mode == LocomotionMode.POINT_TURN.value):
-            steering_angles[self.FL] = 45
-            steering_angles[self.FR] = -45
-            steering_angles[self.RL] = -45
-            steering_angles[self.RR] = 45
+            point_turn_angle = int(math.degrees(math.atan((self.wheel_x+self.wheel_fx) / self.wheel_y)))
+            #For ExoMy approx. 55 degree
+            steering_angles[self.FL] = point_turn_angle
+            steering_angles[self.FR] = -point_turn_angle
+            steering_angles[self.RL] = -point_turn_angle
+            steering_angles[self.RR] = point_turn_angle
 
             return steering_angles
         if(self.locomotion_mode == LocomotionMode.CRABBING.value):
@@ -237,12 +239,14 @@ class Rover():
                 motor_speeds[self.RR] = -50
 
             return motor_speeds
-
+            
         if (self.locomotion_mode == LocomotionMode.ACKERMANN.value):
+            
+            #Speed parameters
             v = driving_command
             if(steering_command < 0):
                 v *= -1
-
+            
             # Scale between min and max Ackermann radius
             radius = self.ackermann_r_max - \
                 abs(math.cos(math.radians(steering_command))) * \
@@ -287,20 +291,20 @@ class Rover():
             if(driving_command is not 0):
                 # Left turn
                 if(deg < 85 and deg > -85):
-                    motor_speeds[self.FL] = -50
-                    motor_speeds[self.FR] = 50
-                    motor_speeds[self.CL] = -50
-                    motor_speeds[self.CR] = 50
-                    motor_speeds[self.RL] = -50
-                    motor_speeds[self.RR] = 50
+                    motor_speeds[self.FL] = -v
+                    motor_speeds[self.FR] = v
+                    motor_speeds[self.CL] = -v
+                    motor_speeds[self.CR] = v
+                    motor_speeds[self.RL] = -v
+                    motor_speeds[self.RR] = v
                 # Right turn
                 elif(deg > 95 or deg < -95):
-                    motor_speeds[self.FL] = 50
-                    motor_speeds[self.FR] = -50
-                    motor_speeds[self.CL] = 50
-                    motor_speeds[self.CR] = -50
-                    motor_speeds[self.RL] = 50
-                    motor_speeds[self.RR] = -50
+                    motor_speeds[self.FL] = v
+                    motor_speeds[self.FR] = -v
+                    motor_speeds[self.CL] = v
+                    motor_speeds[self.CR] = -v
+                    motor_speeds[self.RL] = v
+                    motor_speeds[self.RR] = -v
             else:
                 # Stop
                 motor_speeds[self.FL] = 0
@@ -315,18 +319,18 @@ class Rover():
         if(self.locomotion_mode == LocomotionMode.CRABBING.value):
             if(driving_command > 0):
                 if(steering_command > 0):
-                    motor_speeds[self.FL] = 50
-                    motor_speeds[self.FR] = 50
-                    motor_speeds[self.CL] = 50
-                    motor_speeds[self.CR] = 50
-                    motor_speeds[self.RL] = 50
-                    motor_speeds[self.RR] = 50
+                    motor_speeds[self.FL] = v
+                    motor_speeds[self.FR] = v
+                    motor_speeds[self.CL] = v
+                    motor_speeds[self.CR] = v
+                    motor_speeds[self.RL] = v
+                    motor_speeds[self.RR] = v
                 elif(steering_command <= 0):
-                    motor_speeds[self.FL] = -50
-                    motor_speeds[self.FR] = -50
-                    motor_speeds[self.CL] = -50
-                    motor_speeds[self.CR] = -50
-                    motor_speeds[self.RL] = -50
-                    motor_speeds[self.RR] = -50
+                    motor_speeds[self.FL] = -v
+                    motor_speeds[self.FR] = -v
+                    motor_speeds[self.CL] = -v
+                    motor_speeds[self.CR] = -v
+                    motor_speeds[self.RL] = -v
+                    motor_speeds[self.RR] = -v
 
         return motor_speeds

--- a/src/rover.py
+++ b/src/rover.py
@@ -185,9 +185,13 @@ class Rover():
 
         if(self.locomotion_mode == LocomotionMode.POINT_TURN.value):
             point_turn_angle = int(math.degrees(math.atan((self.wheel_x+self.wheel_fx) / self.wheel_y)))
+            
+            point_turn_angle_center = int(math.degrees(math.atan((((self.wheel_x+self.wheel_fx) / 2 ) - self.wheel_x) / (self.wheel_y / 2))))
             #For ExoMy approx. 55 degree
             steering_angles[self.FL] = point_turn_angle
             steering_angles[self.FR] = -point_turn_angle
+            steering_angles[self.CL] = point_turn_angle_center
+            steering_angles[self.CR] = -point_turn_angle_center
             steering_angles[self.RL] = -point_turn_angle
             steering_angles[self.RR] = point_turn_angle
 
@@ -287,24 +291,30 @@ class Rover():
                 return motor_speeds
 
         if (self.locomotion_mode == LocomotionMode.POINT_TURN.value):
+            outer_turning_radius = math.sqrt(math.pow(self.wheel_x+self.wheel_fx,2) + math.pow(self.wheel_y,2)) / 2
+            inner_turning_radius = math.sqrt(math.pow(((self.wheel_x+self.wheel_fx) / 2 ) - self.wheel_x,2) + math.pow((self.wheel_y / 2),2))
+            
+            v_outer = v
+            v_inner = int(v*inner_turning_radius/outer_turning_radius)
+            
             deg = steering_command
             if(driving_command is not 0):
                 # Left turn
                 if(deg < 85 and deg > -85):
-                    motor_speeds[self.FL] = -v
-                    motor_speeds[self.FR] = v
-                    motor_speeds[self.CL] = -v
-                    motor_speeds[self.CR] = v
-                    motor_speeds[self.RL] = -v
-                    motor_speeds[self.RR] = v
+                    motor_speeds[self.FL] = -v_outer
+                    motor_speeds[self.FR] = v_outer
+                    motor_speeds[self.CL] = -v_inner
+                    motor_speeds[self.CR] = v_inner
+                    motor_speeds[self.RL] = -v_outer
+                    motor_speeds[self.RR] = v_outer
                 # Right turn
                 elif(deg > 95 or deg < -95):
-                    motor_speeds[self.FL] = v
-                    motor_speeds[self.FR] = -v
-                    motor_speeds[self.CL] = v
-                    motor_speeds[self.CR] = -v
-                    motor_speeds[self.RL] = v
-                    motor_speeds[self.RR] = -v
+                    motor_speeds[self.FL] = v_outer
+                    motor_speeds[self.FR] = -v_outer
+                    motor_speeds[self.CL] = v_inner
+                    motor_speeds[self.CR] = -v_inner
+                    motor_speeds[self.RL] = v_outer
+                    motor_speeds[self.RR] = -v_outer
             else:
                 # Stop
                 motor_speeds[self.FL] = 0

--- a/src/rover.py
+++ b/src/rover.py
@@ -13,7 +13,7 @@ class Rover():
     FL, FR, CL, CR, RL, RR = range(0, 6)
 
     # Defining locomotion modes
-    ACKERMANN, POINT_TURN, CRABBING = range(1, 4)
+    FAKE_ACKERMANN, ACKERMANN, POINT_TURN, CRABBING = range(0, 4)
 
     def __init__(self):
         self.locomotion_mode = LocomotionMode.ACKERMANN
@@ -67,40 +67,91 @@ class Rover():
         steering_angles = [0]*6
         deg = steering_command
         
+        if(self.locomotion_mode == LocomotionMode.FAKE_ACKERMANN.value):
+            if (driving_command == 0):
+                # Stop
+                steering_angles[self.FL] = 0
+                steering_angles[self.FR] = 0
+                steering_angles[self.CR] = 0
+                steering_angles[self.CL] = 0
+                steering_angles[self.RL] = 0
+                steering_angles[self.RR] = 0
+                return steering_angles
+
+            if(80 < deg < 100):
+                # Drive straight forward
+                steering_angles[self.FL] = 0
+                steering_angles[self.FR] = 0
+                steering_angles[self.CR] = 0
+                steering_angles[self.CL] = 0
+                steering_angles[self.RL] = 0
+                steering_angles[self.RR] = 0
+            elif(-80 < deg < -100):
+                # Drive straight backwards
+                steering_angles[self.FL] = 0
+                steering_angles[self.FR] = 0
+                steering_angles[self.CR] = 0
+                steering_angles[self.CL] = 0
+                steering_angles[self.RL] = 0
+                steering_angles[self.RR] = 0
+            elif(100 < deg <= 180):
+                # Drive right forwards
+                steering_angles[self.FL] = 45
+                steering_angles[self.FR] = 45
+                steering_angles[self.CR] = 0
+                steering_angles[self.CL] = 0
+                steering_angles[self.RL] = -45
+                steering_angles[self.RR] = -45
+            elif(-100 > deg >= -180):
+                # Drive right backwards
+                steering_angles[self.FL] = 45
+                steering_angles[self.FR] = 45
+                steering_angles[self.CR] = 0
+                steering_angles[self.CL] = 0
+                steering_angles[self.RL] = -45
+                steering_angles[self.RR] = -45
+            elif(80 > deg >= 0):
+                # Drive left forwards
+                steering_angles[self.FL] = -45
+                steering_angles[self.FR] = -45
+                steering_angles[self.CR] = 0
+                steering_angles[self.CL] = 0
+                steering_angles[self.RL] = 45
+                steering_angles[self.RR] = 45
+            elif(0 > deg > -80):
+                # Drive left backwards
+                steering_angles[self.FL] = -45
+                steering_angles[self.FR] = -45
+                steering_angles[self.CR] = 0
+                steering_angles[self.CL] = 0
+                steering_angles[self.RL] = 45
+                steering_angles[self.RR] = 45
+
+            return steering_angles
+
         if(self.locomotion_mode == LocomotionMode.ACKERMANN.value):
 
             # No steering if robot is not driving
             if(driving_command is 0):
                 return steering_angles
 
-            # Rear: Scale between min and max Ackermann radius
+            # Radius: Scale between min and max Ackermann radius
             if math.cos(math.radians(steering_command)) == 0:
-                rr = self.ackermann_r_max
-            else:
-                rr = self.ackermann_r_max - \
-                    abs(math.cos(math.radians(steering_command))) * \
-                    ((self.ackermann_r_max-self.ackermann_r_min))
-
-            # Front: Scale between min and max Ackermann radius
-            if math.cos(math.radians(steering_command)) == 0:
-                fr = self.ackermann_r_max
-            else:
-                fr = self.ackermann_r_max - \
-                    abs(math.cos(math.radians(steering_command))) * \
-                    ((self.ackermann_r_max-self.ackermann_r_min))
- 
-               
-            # No steering
-            if rr == self.ackermann_r_max:
+                # No steering
                 return steering_angles
+            else:
+                # Scale between min and max Ackermann radius
+                radius = self.ackermann_r_max - \
+                abs(math.cos(math.radians(steering_command))) * \
+                ((self.ackermann_r_max-self.ackermann_r_min))
 
             # Rear
-            rear_inner_angle = int(math.degrees(math.atan(self.wheel_rx/(abs(rr)-(self.wheel_ry/2)))))
-            rear_outer_angle = int(math.degrees(math.atan(self.wheel_rx/(abs(rr)+(self.wheel_ry/2)))))
+            rear_inner_angle = int(math.degrees(math.atan(self.wheel_rx/(abs(radius)-(self.wheel_ry/2)))))
+            rear_outer_angle = int(math.degrees(math.atan(self.wheel_rx/(abs(radius)+(self.wheel_ry/2)))))
             
             # Front
-            front_inner_angle = int(math.degrees(math.atan(self.wheel_fx/(abs(fr)-(self.wheel_fy/2)))))
-            front_outer_angle = int(math.degrees(math.atan(self.wheel_fx/(abs(fr)+(self.wheel_fy/2)))))
+            front_inner_angle = int(math.degrees(math.atan(self.wheel_fx/(abs(radius)-(self.wheel_fy/2)))))
+            front_outer_angle = int(math.degrees(math.atan(self.wheel_fx/(abs(radius)+(self.wheel_fy/2)))))
 
             if steering_command > 90 or steering_command < -90:
                 # Steering to the right
@@ -159,7 +210,26 @@ class Rover():
         '''
 
         motor_speeds = [0]*6
-            
+        
+        if (self.locomotion_mode == LocomotionMode.FAKE_ACKERMANN.value):
+            if(driving_command > 0 and steering_command >= 0):
+                motor_speeds[self.FL] = 50
+                motor_speeds[self.FR] = 50
+                motor_speeds[self.CR] = 50
+                motor_speeds[self.CL] = 50
+                motor_speeds[self.RL] = 50
+                motor_speeds[self.RR] = 50
+
+            elif(driving_command > 0 and steering_command <= 0):
+                motor_speeds[self.FL] = -50
+                motor_speeds[self.FR] = -50
+                motor_speeds[self.CR] = -50
+                motor_speeds[self.CL] = -50
+                motor_speeds[self.RL] = -50
+                motor_speeds[self.RR] = -50
+
+            return motor_speeds
+
         if (self.locomotion_mode == LocomotionMode.ACKERMANN.value):
             
             #Speed parameters

--- a/src/rover.py
+++ b/src/rover.py
@@ -16,10 +16,10 @@ class Rover():
     FL, FR, CL, CR, RL, RR = range(0, 6)
 
     # Defining locomotion modes
-    FAKE_ACKERMANN, ACKERMANN, POINT_TURN, CRABBING = range(0, 4)
+    ACKERMANN, POINT_TURN, CRABBING = range(1, 4)
 
     def __init__(self):
-        self.locomotion_mode = LocomotionMode.FAKE_ACKERMANN
+        self.locomotion_mode = LocomotionMode.ACKERMANN
         
         # x = axes distance
         # y = axes width
@@ -70,68 +70,6 @@ class Rover():
 
         steering_angles = [0]*6
         deg = steering_command
-
-        if(self.locomotion_mode == LocomotionMode.FAKE_ACKERMANN.value):
-            if (driving_command == 0):
-                # Stop
-                steering_angles[self.FL] = 0
-                steering_angles[self.FR] = 0
-                steering_angles[self.CR] = 0
-                steering_angles[self.CL] = 0
-                steering_angles[self.RL] = 0
-                steering_angles[self.RR] = 0
-                return steering_angles
-
-            if(80 < deg < 100):
-                # Drive straight forward
-                steering_angles[self.FL] = 0
-                steering_angles[self.FR] = 0
-                steering_angles[self.CR] = 0
-                steering_angles[self.CL] = 0
-                steering_angles[self.RL] = 0
-                steering_angles[self.RR] = 0
-            elif(-80 < deg < -100):
-                # Drive straight backwards
-                steering_angles[self.FL] = 0
-                steering_angles[self.FR] = 0
-                steering_angles[self.CR] = 0
-                steering_angles[self.CL] = 0
-                steering_angles[self.RL] = 0
-                steering_angles[self.RR] = 0
-            elif(100 < deg <= 180):
-                # Drive right forwards
-                steering_angles[self.FL] = 45
-                steering_angles[self.FR] = 45
-                steering_angles[self.CR] = 0
-                steering_angles[self.CL] = 0
-                steering_angles[self.RL] = -45
-                steering_angles[self.RR] = -45
-            elif(-100 > deg >= -180):
-                # Drive right backwards
-                steering_angles[self.FL] = 45
-                steering_angles[self.FR] = 45
-                steering_angles[self.CR] = 0
-                steering_angles[self.CL] = 0
-                steering_angles[self.RL] = -45
-                steering_angles[self.RR] = -45
-            elif(80 > deg >= 0):
-                # Drive left forwards
-                steering_angles[self.FL] = -45
-                steering_angles[self.FR] = -45
-                steering_angles[self.CR] = 0
-                steering_angles[self.CL] = 0
-                steering_angles[self.RL] = 45
-                steering_angles[self.RR] = 45
-            elif(0 > deg > -80):
-                # Drive left backwards
-                steering_angles[self.FL] = -45
-                steering_angles[self.FR] = -45
-                steering_angles[self.CR] = 0
-                steering_angles[self.CL] = 0
-                steering_angles[self.RL] = 45
-                steering_angles[self.RR] = 45
-
-            return steering_angles
         
         if(self.locomotion_mode == LocomotionMode.ACKERMANN.value):
 
@@ -225,24 +163,6 @@ class Rover():
         '''
 
         motor_speeds = [0]*6
-        if (self.locomotion_mode == LocomotionMode.FAKE_ACKERMANN.value):
-            if(driving_command > 0 and steering_command >= 0):
-                motor_speeds[self.FL] = 50
-                motor_speeds[self.FR] = 50
-                motor_speeds[self.CR] = 50
-                motor_speeds[self.CL] = 50
-                motor_speeds[self.RL] = 50
-                motor_speeds[self.RR] = 50
-
-            elif(driving_command > 0 and steering_command <= 0):
-                motor_speeds[self.FL] = -50
-                motor_speeds[self.FR] = -50
-                motor_speeds[self.CR] = -50
-                motor_speeds[self.CL] = -50
-                motor_speeds[self.RL] = -50
-                motor_speeds[self.RR] = -50
-
-            return motor_speeds
             
         if (self.locomotion_mode == LocomotionMode.ACKERMANN.value):
             


### PR DESCRIPTION
This pull request solves from my point of view a major issue with the Ackermann steering.

Changes made:
- Introducted better values for axle distances and axle width
- Added a separate branch for front Ackermann steering (use center axle as reference), as axle distance rear axle to center and front axle to center is important for the angle
- corrected formulas for Ackermann steering (use axle width devided by 2 )
- recalculated all radius for individual wheel speeds based on updated Ackermann steering radius (center is the center axle; left turn is the basis)
- introduced a reference radius for wheel speed calculation based on biggest radius to avoid that a speed on the joy stick of +-100 does not make a wheel turn faster than +-100.
- corrected speed to wheel assignment (vector cannot be simply reversed as wheels are assigned in FL, FR, CL, CR, RL, RR order; reversing them would make the RR wheel turn faster/slower instead of FR and so on)

Remarks: max_steering_angle is can only be used if steering maximum value is calibrated in "pwm range value" (see  scripts/config_steer_motor_maxsteering.py)